### PR TITLE
Update Bforartists to 5.1.2, remove codec stuff

### DIFF
--- a/de.bforartists.Bforartists.yaml
+++ b/de.bforartists.Bforartists.yaml
@@ -25,119 +25,18 @@ finish-args:
   - --env=VK_ICD_FILENAMES=/app/lib/GL/vulkan/icd.d
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib/GL/default/lib
 
-# We bundle non-free codecs with Bforartists,
-# which are build when the Flatpak is
-# built. To allow users/distro maintainers 
-# to remove non-free codecs, we make this an 
-# extension that can be removed
 add-extensions:
-  de.bforartists.Bforartists.Codecs:
-    directory: lib/codecs
-    add-ld-path: lib
-    bundle: true
-    autodelete: true
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: '24.08'
-    add-ld-path: .
   org.freedesktop.Platform.GL:
     directory: lib/GL
-    versions: 1.4;24.08
+    versions: 1.4;25.08
     subdirectories: true
     add-ld-path: lib:default/lib
     merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;lib/dri
     download-if: active-gl-driver
     enable-if: active-gl-driver
     autoprune-unless: active-gl-driver
-cleanup-commands:
-  - mkdir -p /app/lib/ffmpeg
 modules:
   - shared-modules/libdecor/libdecor-0.2.0.json
-
-  # Build codecs, including non-free ones
-  - name: x264
-    config-opts:
-      - --prefix=/app/lib/codecs
-      - --enable-lto
-      - --enable-pic
-      - --enable-shared
-      - --disable-cli
-    sources:
-      - type: git
-        url: https://code.videolan.org/videolan/x264.git
-        commit: 31e19f92f00c7003fa115047ce50978bc98c3a0d
-    cleanup:
-      - /lib/codecs/include
-      - /lib/codecs/lib/pkgconfig
-
-  # We build ffmpeg as Blender (and by extension,
-  # Bforartists) doesn't work well with OpenH264
-  - name: ffmpeg
-    build-options:
-      env:
-        PKG_CONFIG_PATH: /app/lib/codecs/lib/pkgconfig
-    config-opts:
-      - --prefix=/app/lib/codecs
-      - --enable-shared
-      - --disable-static
-      - --disable-doc
-      - --enable-gpl
-      - --enable-version3
-      - --disable-nonfree
-      - --enable-optimizations
-      - --enable-pthreads
-      - --disable-bzlib
-      - --disable-libgsm
-      - --enable-libtheora
-      - --enable-libvorbis
-      - --enable-libvpx
-      - --enable-libx264
-      - --enable-zlib
-      - --disable-libxcb
-      - --disable-lzma
-      - --disable-programs
-      - --disable-network
-      - --disable-protocols
-      - --enable-protocol=file
-      - --disable-devices
-      - --enable-muxer=avi
-      - --enable-muxer=h264
-      - --enable-muxer=mov
-      - --enable-muxer=mp4
-      - --enable-muxer=ogg
-      - --enable-muxer=webm
-      - --enable-demuxer=avi
-      - --enable-demuxer=h264
-      - --enable-demuxer=mov
-      - --enable-demuxer=mp3
-      - --enable-demuxer=ogg
-      - --enable-demuxer=wav
-      - --enable-parser=h264
-      - --enable-parser=vorbis
-      - --enable-encoder=aac
-      - --enable-encoder=libtheora
-      - --enable-encoder=libvorbis
-      - --enable-encoder=libvpx_vp8
-      - --enable-encoder=libvpx_vp9
-      - --enable-encoder=libx264
-      - --enable-encoder=mpeg4
-      - --enable-decoder=aac
-      - --enable-decoder=h264
-      - --enable-decoder=libvorbis
-      - --enable-decoder=libvpx_vp8
-      - --enable-decoder=libvpx_vp9
-      - --enable-decoder=mp3
-      - --enable-decoder=mpeg4
-      - --enable-decoder=pcm_s16le
-      - --enable-decoder=theora
-    sources:
-      - type: archive
-        url: https://www.ffmpeg.org/releases/ffmpeg-6.1.2.tar.xz
-        sha256: 3b624649725ecdc565c903ca6643d41f33bd49239922e45c9b1442c63dca4e38
-    cleanup:
-      - /lib/codecs/include
-      - /lib/codecs/lib/pkgconfig
-      - /lib/codecs/share
 
   # Libcrypt for BlenderKit support
   # https://github.com/flathub/org.blender.Blender/issues/166
@@ -180,8 +79,8 @@ modules:
     # sha256sum <bforartists tar archive>
     sources:
       - type: archive
-        url: https://github.com/Bforartists/Bforartists/releases/download/v5.1.1/Bforartists-5.1.1-Linux.tar.xz
-        sha256: 0cc980b2043407028e5b665be7ebc36a8c22e9ea73ec10adf4ee31538a787d6a
+        url: https://github.com/Bforartists/Bforartists/releases/download/v5.1.2/Bforartists-5.1.2-Linux.tar.xz
+        sha256: 86609a252610ec1959fa5fde2b6b2def848cee9805ca325c2c63cc13e82c106d
         strip-components: 0
 
         # This is to verify that the URL indeed 


### PR DESCRIPTION
Based on what's been said in #34, codecs should now be bundled with the Freedesktop SDK automatically. We'd need end users to test this first, but hopefully that should simplify the manifest.